### PR TITLE
Prune docker images by shelling out

### DIFF
--- a/state/synchronize.go
+++ b/state/synchronize.go
@@ -91,8 +91,8 @@ func (s *SessionLease) Synchronize(settings SyncSettings) (*Delta, []error) {
 		s.Log.WithError(err).Warn("Unable to read disk usage")
 	} else if usage >= 70 {
     s.Log.WithField("usage", usage).Warn("Disk is getting full: prune advised.")
-		// s.Log.Info("Pruning unused docker data.")
-		// s.Prune()
+		s.Log.Info("Pruning unused docker data.")
+		s.Prune()
 	} else {
 		s.Log.WithField("usage", usage).Info("No prune necessary yet.")
 	}

--- a/web/health.go
+++ b/web/health.go
@@ -1,0 +1,85 @@
+package web
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type healthReport struct {
+	DiskUsagePercent int `json:"diskUsagePercent"`
+}
+
+func (s *Server) handleHealthRoot(w http.ResponseWriter, r *http.Request) {
+	s.methods(w, r, methodHandlerMap{
+		http.MethodGet:  func() { s.handleGetHealth(w, r) },
+		http.MethodPost: func() { s.handlePostHealth(w, r) },
+	})
+}
+
+func (s *Server) handleGetHealth(w http.ResponseWriter, r *http.Request) {
+	session, err := s.pool.Take()
+	if err != nil {
+		log.WithError(err).Error("Unable to establish a session.")
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("Unable to establish a session."))
+		return
+	}
+	defer session.Release()
+
+	diskUsage, err := session.ReadDiskUsage()
+	if err != nil {
+		session.Log.WithError(err).Warn("Unable to read disk usage")
+	}
+
+	report := healthReport{
+		DiskUsagePercent: diskUsage,
+	}
+
+	if err = json.NewEncoder(w).Encode(&report); err != nil {
+		session.Log.WithError(err).Error("Unable to serialize JSON.")
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("Unable to serialize JSON"))
+		return
+	}
+}
+
+type healthRequest struct {
+	Action string `json:"action"`
+}
+
+func (s *Server) handlePostHealth(w http.ResponseWriter, r *http.Request) {
+	session, err := s.pool.Take()
+	if err != nil {
+		log.WithError(err).Error("Unable to establish session.")
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("Unable to establish session."))
+		return
+	}
+	defer session.Release()
+
+	var req healthRequest
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&req); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(w, "Unable to deserialize secrets map: %v", err)
+		return
+	}
+
+	switch req.Action {
+	case "prune":
+		session.Prune()
+		w.Write([]byte("ok"))
+		return
+	case "":
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("\"action\" is required"))
+		return
+	default:
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(w, "Unrecognized health action: %v", req.Action)
+		return
+	}
+}

--- a/web/main.go
+++ b/web/main.go
@@ -45,6 +45,7 @@ func NewServer(opts *config.Options, db *sql.DB, ring *secrets.DecoderRing) (*Se
 	http.HandleFunc("/actual", s.wrap(s.handleActualRoot, true))
 	http.HandleFunc("/diff", s.wrap(s.handleDiffRoot, true))
 	http.HandleFunc("/sync", s.wrap(s.handleSyncRoot, true))
+	http.HandleFunc("/health", s.wrap(s.handleHealthRoot, true))
 
 	return &s, nil
 }


### PR DESCRIPTION
Shell out to the docker binary to prune to avoid the lockup issues I was seeing doing it directly through the docker SDK. Add a `/health` endpoint to query the current disk usage and trigger pruning manually.